### PR TITLE
Fix infinite z-score issue in calculateCriterion() using epsilon correction

### DIFF
--- a/src/pyWitness/DataProcessed.py
+++ b/src/pyWitness/DataProcessed.py
@@ -489,24 +489,21 @@ class DataProcessed :
         return dPrime
 
     def calculateCriterion(self):
-        # Add epsilon correction to prevent infinite z-scores
-        epsilon = 0.5 / len(self.dataRaw.data)  # Laplace correction
-        hit_rate = self.data_rates.loc['targetPresent','suspectId'].values
-        fa_rate = self.data_rates.loc['targetAbsent','suspectId'].values
+        epsilon = 0.5 / len(self.dataRaw.data)
+        hit_rate = self.data_rates.loc['targetPresent','suspectId'].copy()
 
-        # Clip rates to avoid 0.0 and 1.0
-        hit_rate = _np.clip(hit_rate, epsilon, 1 - epsilon)
-        fa_rate = _np.clip(fa_rate, epsilon, 1 - epsilon)
+        try :
+            fa_rate = self.data_rates.loc['targetAbsent','suspectId'].copy()
+        except KeyError:
+            fa_rate = self.data_rates.loc['targetAbsent','rejectId'].copy()
 
+        hit_rate = hit_rate.clip(lower=epsilon, upper=1 - epsilon)
+        fa_rate = fa_rate.clip(lower=epsilon, upper=1 - epsilon)
         zT = _special.ndtri(hit_rate)
-        try:
-            zL = _special.ndtri(fa_rate)
-        except : # only for TA showups and the participant never made a suspectId
-            zL = _special.ndtri(self.data_rates.loc['targetAbsent','rejectId'])
+        zL = _special.ndtri(fa_rate)
 
         dCriterion = - (zT + zL)/2.0
-        template = self.data_rates.loc['dprime', 'central']  # Use existing row as template
-        dCriterion = _pandas.Series(dCriterion, name=("criterion", "central"), index=template.index)
+        dCriterion.name = ("criterion", "central")
         self.data_rates = _pandas.concat([self.data_rates, _pandas.DataFrame(dCriterion).transpose()])
         self.data_rates = self.data_rates.sort_index()
 

--- a/src/pyWitness/DataProcessed.py
+++ b/src/pyWitness/DataProcessed.py
@@ -489,13 +489,22 @@ class DataProcessed :
         return dPrime
 
     def calculateCriterion(self):
-        zT = _special.ndtri(self.data_rates.loc['targetPresent','suspectId'])
-        try :
-            zL = _special.ndtri(self.data_rates.loc['targetAbsent','suspectId'])
-        except : # only for TA showups and the participant never made a suspectId
-            zL = _special.ndtri(self.data_rates.loc['targetAbsent','rejectId'])
+        # Add epsilon correction to prevent infinite z-scores
+        epsilon = 0.5 / len(self.dataRaw.data)  # Laplace correction
+        hit_rate = self.data_rates.loc['targetPresent', 'suspectId'].values
+        fa_rate = self.data_rates.loc['targetAbsent', 'suspectId'].values
 
-        dCriterion = - (zT + zL)/2.0
+        # Clip rates to avoid 0.0 and 1.0
+        hit_rate = _np.clip(hit_rate, epsilon, 1 - epsilon)
+        fa_rate = _np.clip(fa_rate, epsilon, 1 - epsilon)
+
+        zT = _special.ndtri(hit_rate)
+        try:
+            zL = _special.ndtri(fa_rate)
+        except:  # only for TA showups and the participant never made a suspectId
+            zL = _special.ndtri(self.data_rates.loc['targetAbsent', 'rejectId'])
+
+        dCriterion = - (zT + zL) / 2.0
         dCriterion.name = ("criterion", "central")
         self.data_rates = _pandas.concat([self.data_rates, _pandas.DataFrame(dCriterion).transpose()])
         self.data_rates = self.data_rates.sort_index()

--- a/src/pyWitness/DataProcessed.py
+++ b/src/pyWitness/DataProcessed.py
@@ -491,8 +491,8 @@ class DataProcessed :
     def calculateCriterion(self):
         # Add epsilon correction to prevent infinite z-scores
         epsilon = 0.5 / len(self.dataRaw.data)  # Laplace correction
-        hit_rate = self.data_rates.loc['targetPresent', 'suspectId'].values
-        fa_rate = self.data_rates.loc['targetAbsent', 'suspectId'].values
+        hit_rate = self.data_rates.loc['targetPresent','suspectId'].values
+        fa_rate = self.data_rates.loc['targetAbsent','suspectId'].values
 
         # Clip rates to avoid 0.0 and 1.0
         hit_rate = _np.clip(hit_rate, epsilon, 1 - epsilon)
@@ -501,11 +501,12 @@ class DataProcessed :
         zT = _special.ndtri(hit_rate)
         try:
             zL = _special.ndtri(fa_rate)
-        except:  # only for TA showups and the participant never made a suspectId
-            zL = _special.ndtri(self.data_rates.loc['targetAbsent', 'rejectId'])
+        except : # only for TA showups and the participant never made a suspectId
+            zL = _special.ndtri(self.data_rates.loc['targetAbsent','rejectId'])
 
-        dCriterion = - (zT + zL) / 2.0
-        dCriterion.name = ("criterion", "central")
+        dCriterion = - (zT + zL)/2.0
+        template = self.data_rates.loc['dprime', 'central']  # Use existing row as template
+        dCriterion = _pandas.Series(dCriterion, name=("criterion", "central"), index=template.index)
         self.data_rates = _pandas.concat([self.data_rates, _pandas.DataFrame(dCriterion).transpose()])
         self.data_rates = self.data_rates.sort_index()
 


### PR DESCRIPTION
This PR adds an epsilon correction to DataProcessed.calculateCriterion() to prevent infinite z-scores when hit rates or false alarm rates take boundary values 0/1.
- Before applying the inverse normal transform, the rates are clipped using the epsilon bound.
- All tests passed.